### PR TITLE
create_loc_conf must return NULL on error

### DIFF
--- a/src/ngx_http_set_misc_module.c
+++ b/src/ngx_http_set_misc_module.c
@@ -453,7 +453,7 @@ ngx_http_set_misc_create_loc_conf(ngx_conf_t *cf)
 
     conf = ngx_palloc(cf->pool, sizeof(ngx_http_set_misc_loc_conf_t));
     if (conf == NULL) {
-        return NGX_CONF_ERROR;
+        return NULL;
     }
 
     conf->base32_padding = NGX_CONF_UNSET;


### PR DESCRIPTION
This is same issue as: https://github.com/openresty/echo-nginx-module/pull/35
