### PR TITLE
Add set_secure_random_hex

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,7 @@ Table of Contents
     * [set_random](#set_random)
     * [set_secure_random_alphanum](#set_secure_random_alphanum)
     * [set_secure_random_lcalpha](#set_secure_random_lcalpha)
+    * [set_secure_random_hex](#set_secure_random_hex)
     * [set_rotate](#set_rotate)
     * [set_local_today](#set_local_today)
     * [set_formatted_gmt_time](#set_formatted_gmt_time)
@@ -920,7 +921,7 @@ Behind the scene, it makes use of the standard C function `rand()`.
 
 This directive was first introduced in the `v0.22rc1` release.
 
-See also [set_secure_random_alphanum](#set_secure_random_alphanum) and [set_secure_random_lcalpha](#set_secure_random_lcalpha).
+See also [set_secure_random_alphanum](#set_secure_random_alphanum), [set_secure_random_lcalpha](#set_secure_random_lcalpha) and [set_secure_random_hex](#set_secure_random_hex).
 
 [Back to TOC](#table-of-contents)
 
@@ -953,8 +954,7 @@ then request `GET /test` will output a string like `ivVVRP2DGaAqDmdf3Rv4ZDJ7k0gO
 
 This functionality depends on the presence of the `/dev/urandom` device, available on most UNIX-like systems.
 
-See also [set_secure_random_lcalpha](#set_secure_random_lcalpha) and [set_random](#set_random).
-
+See also [set_secure_random_lcalpha](#set_secure_random_lcalpha), [set_random](#set_random) and [set_secure_random_hex](#set_secure_random_hex).
 This directive was first introduced in the `v0.22rc8` release.
 
 [Back to TOC](#table-of-contents)
@@ -990,7 +990,43 @@ This functionality depends on the presence of the `/dev/urandom` device, availab
 
 This directive was first introduced in the `v0.22rc8` release.
 
-See also [set_secure_random_alphanum](#set_secure_random_alphanum) and [set_random](#set_random).
+See also [set_secure_random_alphanum](#set_secure_random_alphanum), [set_random](#set_random) and [set_secure_random_hex](#set_secure_random_hex).
+
+[Back to TOC](#table-of-contents)
+
+
+set_secure_random_hex
+---------------------
+**syntax:** *set_secure_random_hex $res &lt;length&gt;*
+
+**default:** *no*
+
+**context:** *location, location if*
+
+**phase:** *rewrite*
+
+Generates a cryptographically-strong random string `<length>` characters long with the alphabet `[0-9a-f]` (hexadecimal digits).
+
+`<length>` may be between 1 and 64, inclusive.
+
+For instance,
+
+```nginx
+
+ location /test {
+     set_secure_random_hex $res 16;
+
+     echo $res;
+ }
+```
+
+then request `GET /test` will output a string like `1f7213a9fbcd4890`.
+
+This functionality depends on the presence of the `/dev/urandom` device, available on most UNIX-like systems.
+
+This directive was first introduced in the `0.29` release.
+
+See also [set_secure_random_alphanum](#set_secure_random_alphanum), [set_random](#set_random) and [set_secure_random_lcalpha](#set_secure_random_lcalpha).
 
 [Back to TOC](#table-of-contents)
 

--- a/doc/HttpSetMiscModule.wiki
+++ b/doc/HttpSetMiscModule.wiki
@@ -779,7 +779,7 @@ Behind the scene, it makes use of the standard C function <code>rand()</code>.
 
 This directive was first introduced in the <code>v0.22rc1</code> release.
 
-See also [[#set_secure_random_alphanum|set_secure_random_alphanum]] and [[#set_secure_random_lcalpha|set_secure_random_lcalpha]].
+See also [[#set_secure_random_alphanum|set_secure_random_alphanum]], [[#set_secure_random_lcalpha|set_secure_random_lcalpha]] and [[#set_secure_random_hex|set_secure_random_hex]].
 
 == set_secure_random_alphanum ==
 '''syntax:''' ''set_secure_random_alphanum $res <length>''
@@ -808,7 +808,7 @@ then request <code>GET /test</code> will output a string like <code>ivVVRP2DGaAq
 
 This functionality depends on the presence of the <code>/dev/urandom</code> device, available on most UNIX-like systems.
 
-See also [[#set_secure_random_lcalpha|set_secure_random_lcalpha]] and [[#set_random|set_random]].
+See also [[#set_secure_random_lcalpha|set_secure_random_lcalpha]] [[#set_secure_random_hex|set_secure_random_hex]] and [[#set_random|set_random]].
 
 This directive was first introduced in the <code>v0.22rc8</code> release.
 
@@ -841,7 +841,38 @@ This functionality depends on the presence of the <code>/dev/urandom</code> devi
 
 This directive was first introduced in the <code>v0.22rc8</code> release.
 
-See also [[#set_secure_random_alphanum|set_secure_random_alphanum]] and [[#set_random|set_random]].
+See also [[#set_secure_random_alphanum|set_secure_random_alphanum]], [[#set_secure_random_hex|set_secure_random_hex]] and [[#set_random|set_random]].
+
+== set_secure_random_hex ==
+'''syntax:''' ''set_secure_random_hex $res <length>''
+
+'''default:''' ''no''
+
+'''context:''' ''location, location if''
+
+'''phase:''' ''rewrite''
+
+Generates a cryptographically-strong random string <code><length></code> characters long with the alphabet <code>[0-9a-f]</code> (hexadecimal digits).
+
+<code><length></code> may be between 1 and 64, inclusive.
+
+For instance,
+
+<geshi lang="nginx">
+    location /test {
+        set_secure_random_hex $res 16;
+
+        echo $res;
+    }
+</geshi>
+
+then request <code>GET /test</code> will output a string like <code>1f28acd3e287349a</code>.
+
+This functionality depends on the presence of the <code>/dev/urandom</code> device, available on most UNIX-like systems.
+
+This directive was first introduced in the <code>v0.22rc8</code> release.
+
+See also [[#set_secure_random_alphanum|set_secure_random_alphanum]], [[#set_secure_random_lcalpha|set_secure_random_lcalpha]] and [[#set_random|set_random]].
 
 == set_rotate ==
 '''syntax:''' ''set_rotate $value <from> <to>''

--- a/src/ngx_http_set_misc_module.c
+++ b/src/ngx_http_set_misc_module.c
@@ -204,6 +204,12 @@ static ndk_set_var_t  ngx_http_set_misc_set_secure_random_lcalpha_filter = {
     NULL
 };
 
+static ndk_set_var_t  ngx_http_set_misc_set_secure_random_hex_filter = {
+    NDK_SET_VAR_VALUE,
+    (void *) ngx_http_set_misc_set_secure_random_hex,
+    1,
+    NULL
+};
 
 static ngx_command_t  ngx_http_set_misc_commands[] = {
     {   ngx_string ("set_encode_base64"),
@@ -428,6 +434,14 @@ static ngx_command_t  ngx_http_set_misc_commands[] = {
         0,
         0,
         &ngx_http_set_misc_set_secure_random_lcalpha_filter
+    },
+    {   ngx_string ("set_secure_random_hex"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF
+            |NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE12,
+        ndk_set_var_value,
+        0,
+        0,
+        &ngx_http_set_misc_set_secure_random_hex_filter
     },
     {   ngx_string ("set_rotate"),
         NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF

--- a/src/ngx_http_set_secure_random.c
+++ b/src/ngx_http_set_secure_random.c
@@ -12,7 +12,8 @@
 enum {
     MAX_RANDOM_STRING = 64,
     ALPHANUM = 1,
-    LCALPHA  = 2
+    LCALPHA  = 2,
+    HEXONLY = 3
 };
 
 
@@ -36,6 +37,12 @@ ngx_http_set_misc_set_secure_random_lcalpha(ngx_http_request_t *r,
     return ngx_http_set_misc_set_secure_random_common(LCALPHA, r, res, v);
 }
 
+ngx_int_t
+ngx_http_set_misc_set_secure_random_hex(ngx_http_request_t *r,
+    ngx_str_t *res, ngx_http_variable_value_t *v)
+{
+    return ngx_http_set_misc_set_secure_random_common(HEXONLY, r, res, v);
+}
 
 static ngx_int_t
 ngx_http_set_misc_set_secure_random_common(int alphabet_type,
@@ -43,6 +50,7 @@ ngx_http_set_misc_set_secure_random_common(int alphabet_type,
 {
     static u_char  alphabet[] = "abcdefghijklmnopqrstuvwxyz"
                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    static u_char  hexalpha[] = "0123456789abcdef";
 
     u_char         entropy[MAX_RANDOM_STRING];
     u_char         output[MAX_RANDOM_STRING];
@@ -77,9 +85,10 @@ ngx_http_set_misc_set_secure_random_common(int alphabet_type,
     ngx_close_file(fd);
 
     for (i = 0; i < length; i++) {
-        if (alphabet_type == LCALPHA) {
+        if (alphabet_type == HEXONLY) {
+            output[i] = hexalpha[ entropy[i] % 16 ];
+        } else if (alphabet_type == LCALPHA) {
             output[i] = entropy[i] % 26 + 'a';
-
         } else {
             output[i] = alphabet[ entropy[i] % (sizeof alphabet - 1) ];
         }

--- a/src/ngx_http_set_secure_random.h
+++ b/src/ngx_http_set_secure_random.h
@@ -11,5 +11,8 @@ ngx_int_t ngx_http_set_misc_set_secure_random_alphanum(ngx_http_request_t *r,
 ngx_int_t ngx_http_set_misc_set_secure_random_lcalpha(ngx_http_request_t *r,
         ngx_str_t *res, ngx_http_variable_value_t *v);
 
+ngx_int_t ngx_http_set_misc_set_secure_random_hex(ngx_http_request_t *r,
+        ngx_str_t *res, ngx_http_variable_value_t *v);
+
 #endif /* NGX_SET_SECURE_RANDOM_H */
 

--- a/t/secure-random.t
+++ b/t/secure-random.t
@@ -106,3 +106,16 @@ __DATA__
     GET /lcalpha
 --- response_body_like: ^[a-z]{16}$
 
+
+
+=== TEST 8: a 13-character hex
+--- config
+    location /hex {
+        set_secure_random_hex $res 13;
+
+        echo $res;
+    }
+--- request
+    GET /hex
+--- response_body_like: ^[0-9a-f]{13}$
+


### PR DESCRIPTION
Create a random hexadecimal string. Very useful for making trace-ids in X-B3-* headers for zipkin.
