### PR TITLE
Fix building with GCC 7

### DIFF
--- a/src/ngx_http_set_quote_sql.c
+++ b/src/ngx_http_set_quote_sql.c
@@ -97,10 +97,12 @@ ngx_http_pg_utf_islegal(const unsigned char *s, ngx_int_t len)
                 a = *(s + 3);
                 if (a < 0x80 || a > 0xBF)
                     return 0;
+                /* fall through */
             case 3:
                 a = *(s + 2);
                 if (a < 0x80 || a > 0xBF)
                     return 0;
+                /* fall through */
             case 2:
                 a = *(s + 1);
                 switch (*s)


### PR DESCRIPTION
Without introduced comments GCC 7 complains with `-Wimplicit-fallthrough`, which leads to compilation error given the default nginx opts (`-Wall -Werror`):

```
cc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g  -DNDK_SET_VAR -DNDK_UPSTREAM_LIST  -I src/core -I src/event -I src/event/modules -I src/os/unix -I /home/defan/git/ngx_devel_kit/objs -I objs/addon/ndk -I objs -I src/http -I src/http/modules -I /home/defan/git/ngx_devel_kit/src -I /home/defan/git/ngx_devel_kit/src -I /home/defan/git/ngx_devel_kit/objs -I objs/addon/ndk \
	-o objs/addon/src/ngx_http_set_quote_sql.o \
	/home/defan/git/set-misc-nginx-module/src/ngx_http_set_quote_sql.c
/home/defan/git/set-misc-nginx-module/src/ngx_http_set_quote_sql.c: In function ‘ngx_http_pg_utf_islegal’:
/home/defan/git/set-misc-nginx-module/src/ngx_http_set_quote_sql.c:98:20: error: this statement may fall through [-Werror=implicit-fallthrough=]
                 if (a < 0x80 || a > 0xBF)
                    ^
/home/defan/git/set-misc-nginx-module/src/ngx_http_set_quote_sql.c:100:13: note: here
             case 3:
             ^~~~
/home/defan/git/set-misc-nginx-module/src/ngx_http_set_quote_sql.c:102:20: error: this statement may fall through [-Werror=implicit-fallthrough=]
                 if (a < 0x80 || a > 0xBF)
                    ^
/home/defan/git/set-misc-nginx-module/src/ngx_http_set_quote_sql.c:104:13: note: here
             case 2:
             ^~~~
cc1: all warnings being treated as errors
```

Caught this on the following environment:

```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 17.10
Release:	17.10
Codename:	artful

$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/7/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 7.2.0-8ubuntu3' --with-bugurl=file:///usr/share/doc/gcc-7/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++ --prefix=/usr --with-gcc-major-version-only --program-suffix=-7 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --enable-default-pie --with-system-zlib --with-target-system-zlib --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 7.2.0 (Ubuntu 7.2.0-8ubuntu3)
```